### PR TITLE
fix: products loading boundary + rename nav "Products" → "Browse"

### DIFF
--- a/src/app/products/layout.tsx
+++ b/src/app/products/layout.tsx
@@ -1,0 +1,3 @@
+export default function ProductsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -11,7 +11,7 @@ import { BarcodeScanButton } from "@/components/scan"
 
 const navItems = [
   { href: "/", label: "Home", icon: HomeIcon },
-  { href: "/products", label: "Products", icon: ShoppingBasketIcon },
+  { href: "/products", label: "Browse", icon: ShoppingBasketIcon },
   { href: "/favorites", label: "Favorites", icon: HeartIcon },
   { href: "/profile", label: "Profile", icon: UserIcon },
 ] as const

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -72,7 +72,7 @@ export const navigation = [
   },
   {
     icon: ShoppingBasketIcon,
-    label: "Products",
+    label: "Browse",
     href: "/products",
     shownOnDesktop: true,
     shownOnMobile: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two small, independent fixes to the `/products` area.

### 1. Fix wrong skeleton on `/products/{id}` (mobile)

**Root cause:** The `/products` segment had no `layout.tsx`. Without a stable layout shell, Next.js App Router re-renders the parent segment when navigating to a child route (`/products/{id}`), briefly showing the grid skeleton (20 product cards) before the product detail skeleton takes over.

**Fix:** Add a pass-through `layout.tsx` at `src/app/products/layout.tsx`. This creates a stable shell for the segment so its `loading.tsx` only applies to `products/page.tsx` itself — child segments like `[id]` use their own `loading.tsx` as intended.

```
src/app/products/
  layout.tsx   ← new, pass-through shell
  loading.tsx  ← now scoped to list page only
  page.tsx
  [id]/
    loading.tsx  ← fires correctly for product detail
    page.tsx
```

### 2. Rename nav label "Products" → "Browse"

The `/products` page is a filterable search/browse experience, not a static product list. "Browse" is more accurate and avoids the conceptual overlap with the home page's "Products - Browse all" quick action card.

- `src/lib/config.ts` — `navigation` array
- `src/components/layout/BottomNav.tsx` — `navItems` array

The URL (`/products`), icon (`ShoppingBasketIcon`), and the in-page sidebar heading are unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bef3063a-6635-453a-8539-cf7a10265f80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bef3063a-6635-453a-8539-cf7a10265f80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

