### PR TITLE
Products browse discoverability: defaults, brand filter, search sort labels

### DIFF
--- a/src/app/api/og/products/route.tsx
+++ b/src/app/api/og/products/route.tsx
@@ -2,7 +2,14 @@ import { ImageResponse } from "next/og"
 import { loadGeistFontsLight } from "@/lib/og-fonts"
 import { queryStoreProducts, SupermarketChain } from "@/lib/queries/store-products"
 import { buildPageTitle } from "@/lib/business/page-title"
-import { getSearchType, STORE_COLORS, STORE_LOGO_PATHS, STORE_NAMES, type SortByType } from "@/types/business"
+import {
+  getSearchType,
+  STORE_COLORS,
+  STORE_LOGO_PATHS,
+  STORE_NAMES,
+  type SortByType,
+  DEFAULT_BROWSE_SORT,
+} from "@/types/business"
 import { OGFrame, OG_WIDTH, OG_HEIGHT } from "@/lib/og-layout"
 import type { PrioritySource } from "@/types"
 
@@ -22,13 +29,16 @@ export async function GET(request: Request) {
   const query = searchParams.get("q") || undefined
   const searchIn = getSearchType(searchParams.get("t") ?? "any")
   const sortBy = searchParams.get("sort") || undefined
-  const priorityOrder = searchParams.get("priority_order") !== "false"
+  const priorityOrder = searchParams.get("priority_order") === "true"
   const originParam = searchParams.get("origin")
   const categoryParam = searchParams.get("category") || undefined
   const onlyDiscounted = searchParams.get("discounted") === "true"
   const onlyAvailable = searchParams.get("available") !== "false"
   const priorityParam = searchParams.get("priority")
   const sourceParam = searchParams.get("source")
+  const brandParam = searchParams.get("brand")?.trim()
+  const priceMinParam = searchParams.get("price_min")
+  const priceMaxParam = searchParams.get("price_max")
 
   const origins = originParam
     ?.split(",")
@@ -45,6 +55,23 @@ export async function GET(request: Request) {
     .map((v) => v.trim())
     .filter((v): v is PrioritySource => v === "ai" || v === "manual")
 
+  const brandNames = brandParam
+    ? brandParam
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : []
+
+  const priceMin = priceMinParam ? parseFloat(priceMinParam) : undefined
+  const priceMax = priceMaxParam ? parseFloat(priceMaxParam) : undefined
+  const priceRange =
+    (priceMin != null && !isNaN(priceMin)) || (priceMax != null && !isNaN(priceMax))
+      ? {
+          ...(priceMin != null && !isNaN(priceMin) ? { min: priceMin } : {}),
+          ...(priceMax != null && !isNaN(priceMax) ? { max: priceMax } : {}),
+        }
+      : undefined
+
   const title = buildPageTitle({
     query,
     sortBy,
@@ -59,6 +86,8 @@ export async function GET(request: Request) {
     canonicalCategory: categoryId && categoryId > 0 ? { categoryId } : undefined,
     priority: priorityValues?.length ? { values: priorityValues } : undefined,
     source: sourceValues?.length ? { values: sourceValues } : undefined,
+    brand: brandNames.length > 0 ? { names: brandNames } : undefined,
+    priceRange,
     flags: {
       onlyDiscounted,
       onlyAvailable,
@@ -66,7 +95,7 @@ export async function GET(request: Request) {
       minimalSelectForPreview: true,
     },
     pagination: { page: 1, limit: PRODUCTS_AMOUNT },
-    sort: { sortBy: (sortBy as SortByType) || "a-z", prioritizeByPriority: priorityOrder },
+    sort: { sortBy: (sortBy as SortByType) || DEFAULT_BROWSE_SORT, prioritizeByPriority: priorityOrder },
   })
 
   const products = result.data ?? []

--- a/src/app/api/store_products/route.ts
+++ b/src/app/api/store_products/route.ts
@@ -9,6 +9,7 @@ import {
   SupermarketChain,
 } from "@/lib/queries/store-products"
 import type { SearchType, SortByType } from "@/types/business"
+import { DEFAULT_BROWSE_SORT } from "@/types/business"
 import { PrioritySource } from "@/types"
 import { isStoreProductsCacheEnabled, getCachedStoreProducts, setCachedStoreProducts } from "@/lib/kv"
 
@@ -27,8 +28,9 @@ import { isStoreProductsCacheEnabled, getCachedStoreProducts, setCachedStoreProd
  * - category, category_2, category_3: Hierarchical category filter (store-specific)
  * - categories: Semicolon-separated main categories (e.g., "Laticínios;Bebidas")
  * - canonicalCat: Canonical category ID (includes all descendants)
- * - sort: "a-z" | "z-a" | "price-low-high" | "price-high-low" | "only-nulls"
- * - orderByPriority: "true" to order by priority first
+ * - sort: "a-z" | "z-a" | "price-low-high" | "price-high-low" | "relevance" | ...
+ * - orderByPriority: "true" to order by priority first (omit when false)
+ * - brand: comma-separated exact brand names (matches store_products.brand)
  * - page: Page number (1-indexed)
  * - limit: Items per page
  * - onlyDiscounted: "true" to show only discounted products
@@ -263,6 +265,18 @@ function parseSearchParams(params: URLSearchParams): StoreProductsQueryParams {
     }
   }
 
+  // Brand filter (exact names, comma-separated)
+  const brandParam = params.get("brand")?.trim()
+  if (brandParam) {
+    const names = brandParam
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+    if (names.length > 0) {
+      queryParams.brand = { names }
+    }
+  }
+
   // Price range filter
   const priceMinParam = params.get("priceMin")
   const priceMaxParam = params.get("priceMax")
@@ -278,11 +292,9 @@ function parseSearchParams(params: URLSearchParams): StoreProductsQueryParams {
   // Sort options
   const sort = params.get("sort") as SortByType | null
   const orderByPriority = params.get("orderByPriority") === "true"
-  if (sort || orderByPriority) {
-    queryParams.sort = {
-      sortBy: sort ?? "a-z",
-      prioritizeByPriority: orderByPriority,
-    }
+  queryParams.sort = {
+    sortBy: sort ?? DEFAULT_BROWSE_SORT,
+    prioritizeByPriority: orderByPriority,
   }
 
   // Pagination

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -11,6 +11,7 @@ import { Footer } from "@/components/layout/Footer"
 import { HideFooter } from "@/contexts/FooterContext"
 import { siteConfig } from "@/lib/config"
 import type { SearchType, SortByType } from "@/types/business"
+import { DEFAULT_BROWSE_SORT } from "@/types/business"
 import type { PrioritySource } from "@/types"
 import { StoreProductCardSkeleton } from "@/components/products/skeletons/StoreProductCardSkeleton"
 
@@ -43,6 +44,9 @@ export async function generateMetadata({ searchParams }: PageProps): Promise<Met
     "priority",
     "source",
     "category",
+    "brand",
+    "price_min",
+    "price_max",
   ] as const
   const ogParams = new URLSearchParams()
   for (const key of ogParamKeys) {
@@ -87,8 +91,8 @@ function buildServerQueryParams(
       limit,
     },
     sort: {
-      sortBy: (params.sort ?? "updated-newest") as SortByType,
-      prioritizeByPriority: params.priority_order !== "false",
+      sortBy: (params.sort ?? DEFAULT_BROWSE_SORT) as SortByType,
+      prioritizeByPriority: params.priority_order === "true",
     },
     flags: {
       excludeEmptyNames: true,
@@ -131,6 +135,24 @@ function buildServerQueryParams(
     const match = params.category.match(/^(\d+)/)
     const categoryId = match ? parseInt(match[1], 10) : null
     if (categoryId && categoryId > 0) qp.canonicalCategory = { categoryId }
+  }
+
+  const brandParam = params.brand?.trim()
+  if (brandParam) {
+    const names = brandParam
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+    if (names.length > 0) qp.brand = { names }
+  }
+
+  const priceMin = params.price_min ? parseFloat(params.price_min) : undefined
+  const priceMax = params.price_max ? parseFloat(params.price_max) : undefined
+  if ((priceMin != null && !isNaN(priceMin)) || (priceMax != null && !isNaN(priceMax))) {
+    qp.priceRange = {
+      ...(priceMin != null && !isNaN(priceMin) ? { min: priceMin } : {}),
+      ...(priceMax != null && !isNaN(priceMax) ? { max: priceMax } : {}),
+    }
   }
 
   return qp

--- a/src/components/products/StoreProductCard.tsx
+++ b/src/components/products/StoreProductCard.tsx
@@ -14,7 +14,7 @@ import { formatRelativeTime } from "@/lib/business/chart"
 import { discountValueToPercentage, generateProductPath } from "@/lib/business/product"
 
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
-import { Badge } from "@/components/ui/badge"
+import { Badge, badgeVariants } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Barcode } from "@/components/ui/combo/barcode"
 import { CodeShowcase } from "@/components/ui/combo/code-showcase"
@@ -305,9 +305,17 @@ export function StoreProductCard({ sp, imagePriority = false, favoritedAt, showB
           </TooltipProvider>
 
           <div className="mt-1.5 flex items-center justify-between gap-1.5">
-            <span className="w-full text-sm leading-4 font-semibold text-blue-600 dark:text-blue-500">
-              {sp.brand ? sp.brand : <span className="text-muted-foreground opacity-30">No Brand</span>}
-            </span>
+            {sp.brand ? (
+              <Link
+                href={`/products?brand=${encodeURIComponent(sp.brand)}`}
+                className="text-primary hover:text-primary/90 w-full text-sm leading-4 font-semibold underline-offset-2 hover:underline"
+                aria-label={`Browse products for brand ${sp.brand}`}
+              >
+                {sp.brand}
+              </Link>
+            ) : (
+              <span className="text-muted-foreground w-full text-sm leading-4 font-semibold opacity-30">No Brand</span>
+            )}
           </div>
 
           <h2 className="line-clamp-2 min-h-[44px] w-full text-sm font-medium tracking-tight">
@@ -442,9 +450,16 @@ export function StoreProductCard({ sp, imagePriority = false, favoritedAt, showB
               <div className="text-muted-foreground -mt-1 mb-2 flex w-full items-start justify-between gap-1.5 border-b pb-2 text-xs">
                 <div className="flex flex-wrap items-center gap-1.5">
                   {sp.brand && (
-                    <Badge variant="blue" size="xs">
+                    <Link
+                      href={`/products?brand=${encodeURIComponent(sp.brand)}`}
+                      className={cn(
+                        badgeVariants({ variant: "blue", size: "xs" }),
+                        "inline-flex no-underline hover:opacity-90",
+                      )}
+                      aria-label={`Browse products for brand ${sp.brand}`}
+                    >
                       {sp.brand}
-                    </Badge>
+                    </Link>
                   )}
 
                   <TooltipProvider delayDuration={200}>

--- a/src/components/products/store-products-showcase/MobileFiltersDrawer.tsx
+++ b/src/components/products/store-products-showcase/MobileFiltersDrawer.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { CanonicalCategory } from "@/types"
 import { type SearchType, type SortByType } from "@/types/business"
 import { PRODUCT_PRIORITY_LEVELS } from "@/lib/business/priority"
@@ -217,16 +217,28 @@ function storeOriginSummary(selectedOrigins: number[]): string {
     .join(", ")
 }
 
+function brandSummary(brand: string): string {
+  const parts = brand
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+  if (parts.length === 0) return "Any brand"
+  if (parts.length === 1) return parts[0]!
+  return `${parts.length} brands`
+}
+
 // ============================================================================
 // MobileFiltersDrawer
 // ============================================================================
 
-type DrawerView = "filters" | "categories" | "sort" | "stores" | "price"
+type DrawerView = "filters" | "categories" | "sort" | "stores" | "price" | "brand"
 
 export interface MobileFiltersDrawerProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   activeFilterCount: number
+  /** Used to show/hide search relevance sort when there is no active query */
+  searchQueryForSort: string
   localFilters: {
     searchType: SearchType
     sortBy: SortByType
@@ -239,6 +251,7 @@ export interface MobileFiltersDrawerProps {
     category: string
     priceMin: string
     priceMax: string
+    brand: string
   }
   selectedOrigins: number[]
   selectedPriorities: number[]
@@ -251,6 +264,7 @@ export interface MobileFiltersDrawerProps {
   onTogglePriorityOrder: () => void
   onToggleAvailable: () => void
   onToggleDiscounted: () => void
+  onBrandChange: (brand: string) => void
   onPriceRangeChange: (min: string, max: string) => void
 }
 
@@ -258,6 +272,7 @@ export function MobileFiltersDrawer({
   open,
   onOpenChange,
   activeFilterCount,
+  searchQueryForSort,
   localFilters,
   selectedOrigins,
   selectedPriorities,
@@ -270,6 +285,7 @@ export function MobileFiltersDrawer({
   onTogglePriorityOrder,
   onToggleAvailable,
   onToggleDiscounted,
+  onBrandChange,
   onPriceRangeChange,
 }: MobileFiltersDrawerProps) {
   const [view, setView] = useState<DrawerView>("filters")
@@ -282,7 +298,7 @@ export function MobileFiltersDrawer({
     if (!open) setView("filters")
   }, [open])
 
-  const sortLabel = ALL_SORT_LABELS[localFilters.sortBy]?.label ?? "Most Relevant"
+  const sortLabel = ALL_SORT_LABELS[localFilters.sortBy]?.label ?? localFilters.sortBy
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
@@ -301,10 +317,17 @@ export function MobileFiltersDrawer({
         ) : view === "sort" ? (
           <MobileSortPickerView
             currentSort={localFilters.sortBy}
+            showSearchRelevance={Boolean(searchQueryForSort)}
             onSelect={(sort) => {
               onSortChange(sort)
               setView("filters")
             }}
+            onBack={() => setView("filters")}
+          />
+        ) : view === "brand" ? (
+          <MobileBrandFilterView
+            brand={localFilters.brand}
+            onChange={onBrandChange}
             onBack={() => setView("filters")}
           />
         ) : view === "stores" ? (
@@ -326,6 +349,7 @@ export function MobileFiltersDrawer({
             sortLabel={sortLabel}
             categorySummary={selectedCat ? selectedCat.breadcrumb : "All categories"}
             storeSummary={storeOriginSummary(selectedOrigins)}
+            brandSummaryText={brandSummary(localFilters.brand)}
             priceSummary={priceRangeSummary(localFilters.priceMin, localFilters.priceMax)}
             activeFilterCount={activeFilterCount}
             localFilters={localFilters}
@@ -351,6 +375,7 @@ function MainFiltersView({
   sortLabel,
   categorySummary,
   storeSummary,
+  brandSummaryText,
   priceSummary,
   activeFilterCount,
   localFilters,
@@ -365,6 +390,7 @@ function MainFiltersView({
   sortLabel: string
   categorySummary: string
   storeSummary: string
+  brandSummaryText: string
   priceSummary: string
   activeFilterCount: number
   localFilters: MobileFiltersDrawerProps["localFilters"]
@@ -392,6 +418,7 @@ function MainFiltersView({
         <FilterSummaryRow label="Category" value={categorySummary} onClick={() => onViewChange("categories")} />
         <FilterSummaryRow label="Sort By" value={sortLabel} onClick={() => onViewChange("sort")} />
         <FilterSummaryRow label="Store" value={storeSummary} onClick={() => onViewChange("stores")} />
+        <FilterSummaryRow label="Brand" value={brandSummaryText} onClick={() => onViewChange("brand")} />
         <FilterSummaryRow
           label="Price Range"
           value={priceSummary}
@@ -503,19 +530,26 @@ function MainFiltersView({
 
 function MobileSortPickerView({
   currentSort,
+  showSearchRelevance,
   onSelect,
   onBack,
 }: {
   currentSort: SortByType
+  showSearchRelevance: boolean
   onSelect: (sort: SortByType) => void
   onBack: () => void
 }) {
+  const sortGroups = useMemo(() => {
+    if (showSearchRelevance) return SORT_OPTIONS_GROUPS
+    return SORT_OPTIONS_GROUPS.filter((g) => g.label !== "Search")
+  }, [showSearchRelevance])
+
   return (
     <div className="flex h-full flex-col">
       <SubViewHeader title="Sort By" onBack={onBack} />
       <div className="flex-1 overflow-y-auto overscroll-contain px-4">
         <RadioGroup value={currentSort} onValueChange={(v) => onSelect(v as SortByType)} className="gap-0">
-          {SORT_OPTIONS_GROUPS.map((group, gi) => (
+          {sortGroups.map((group, gi) => (
             <div key={group.label} className={cn(gi > 0 && "border-border mt-2 border-t pt-2")}>
               <span className="text-muted-foreground mb-1.5 block text-[11px] font-medium tracking-wider uppercase">
                 {group.label}
@@ -536,6 +570,34 @@ function MobileSortPickerView({
             </div>
           ))}
         </RadioGroup>
+      </div>
+    </div>
+  )
+}
+
+function MobileBrandFilterView({
+  brand,
+  onChange,
+  onBack,
+}: {
+  brand: string
+  onChange: (value: string) => void
+  onBack: () => void
+}) {
+  return (
+    <div className="flex h-full flex-col">
+      <SubViewHeader title="Brand" onBack={onBack} />
+      <div className="flex flex-1 flex-col gap-2 overflow-y-auto overscroll-contain px-4 pb-4">
+        <Label htmlFor="mobile-brand-filter" className="text-muted-foreground text-xs font-medium">
+          Exact names, comma-separated
+        </Label>
+        <Input
+          id="mobile-brand-filter"
+          placeholder="e.g. Kinder, Nestlé"
+          value={brand}
+          onChange={(e) => onChange(e.target.value)}
+          className="text-base"
+        />
       </div>
     </div>
   )

--- a/src/components/products/store-products-showcase/StoreProductsShowcase.tsx
+++ b/src/components/products/store-products-showcase/StoreProductsShowcase.tsx
@@ -7,7 +7,7 @@ import { useStoreProducts, fetchStoreProducts } from "@/hooks/useStoreProducts"
 import { useTrackedDebouncedCallback } from "@/hooks/useTrackedDebouncedCallback"
 import { usePullToRefresh } from "@/hooks/usePullToRefresh"
 import { useMediaQuery } from "@/hooks/useMediaQuery"
-import { searchTypes, type SearchType, type SortByType } from "@/types/business"
+import { searchTypes, type SearchType, type SortByType, DEFAULT_BROWSE_SORT } from "@/types/business"
 import { PRODUCT_PRIORITY_LEVELS } from "@/lib/business/priority"
 import { cn, serializeArray } from "@/lib/utils"
 import { UTILITY_SORT_OPTIONS, ALL_SORT_LABELS } from "@/lib/business/filters"
@@ -83,7 +83,13 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
   const router = useRouter()
   const { urlState, updateUrl, pageTitle } = useUrlState()
 
-  const DEFAULT_ACCORDION_VALUES = ["sort", "store-origin", "price-range", "categories"]
+  useEffect(() => {
+    if (!urlState.query.trim() && urlState.sortBy === "relevance") {
+      updateUrl({ sort: DEFAULT_BROWSE_SORT, page: 1 })
+    }
+  }, [urlState.query, urlState.sortBy, updateUrl])
+
+  const DEFAULT_ACCORDION_VALUES = ["sort", "store-origin", "price-range", "categories", "brand"]
 
   // Desktop detection (lg breakpoint = 1024px) - debounce only applies on desktop
   const isDesktop = useMediaQuery("(min-width: 1024px)")
@@ -105,6 +111,7 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
     category: urlState.category,
     priceMin: urlState.priceMin,
     priceMax: urlState.priceMax,
+    brand: urlState.brand,
   })
 
   // Check if there are pending filter changes (local differs from URL)
@@ -121,7 +128,8 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
       localFilters.source !== urlState.source ||
       localFilters.category !== urlState.category ||
       localFilters.priceMin !== urlState.priceMin ||
-      localFilters.priceMax !== urlState.priceMax
+      localFilters.priceMax !== urlState.priceMax ||
+      localFilters.brand !== urlState.brand
     )
   }, [queryInput, localFilters, urlState])
 
@@ -197,6 +205,7 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
         orderByPriority: urlState.orderByPriority,
         onlyAvailable: urlState.onlyAvailable,
         onlyDiscounted: urlState.onlyDiscounted,
+        brand: urlState.brand,
       }),
     [urlState],
   )
@@ -306,8 +315,15 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
       category: urlState.category,
       priceMin: urlState.priceMin,
       priceMax: urlState.priceMax,
+      brand: urlState.brand,
     })
   }, [urlState])
+
+  const sortOptionsForSelect = useMemo(() => {
+    const hasSearch = Boolean(queryInput.trim()) || Boolean(urlState.query.trim())
+    if (hasSearch) return UTILITY_SORT_OPTIONS
+    return UTILITY_SORT_OPTIONS.filter((o) => o.value !== "relevance")
+  }, [queryInput, urlState.query])
 
   // ============================================================================
   // Handlers
@@ -324,6 +340,7 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
       priority: localFilters.priority || null,
       source: localFilters.source || null,
       category: localFilters.category || null,
+      brand: localFilters.brand.trim() || null,
       priority_order: localFilters.orderByPriority,
       available: localFilters.onlyAvailable,
       discounted: localFilters.onlyDiscounted,
@@ -362,6 +379,7 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
       priority: localFilters.priority || null,
       source: localFilters.source || null,
       category: localFilters.category || null,
+      brand: localFilters.brand.trim() || null,
       priority_order: localFilters.orderByPriority,
       available: localFilters.onlyAvailable,
       discounted: localFilters.onlyDiscounted,
@@ -447,6 +465,16 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
     debouncedUpdateUrl({ category: null, page: 1 })
   }
 
+  const handleBrandInputChange = (value: string) => {
+    setLocalFilters((prev) => ({ ...prev, brand: value }))
+    debouncedUpdateUrl({ brand: value.trim() ? value : null, page: 1 })
+  }
+
+  const handleClearBrand = () => {
+    setLocalFilters((prev) => ({ ...prev, brand: "" }))
+    debouncedUpdateUrl({ brand: null, page: 1 })
+  }
+
   const handleClearFilters = () => {
     debouncedUpdateUrl.cancel()
     setQueryInput("")
@@ -462,6 +490,7 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
       category: FILTER_CONFIG.category.default,
       priceMin: FILTER_CONFIG.priceMin.default,
       priceMax: FILTER_CONFIG.priceMax.default,
+      brand: FILTER_CONFIG.brand.default,
     })
     router.push(window.location.pathname)
   }
@@ -551,6 +580,7 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
     if (urlState.onlyDiscounted) count++
     if (urlState.sortBy !== FILTER_CONFIG.sortBy.default) count++
     if (urlState.priceMin || urlState.priceMax) count++
+    if (urlState.brand.trim()) count++
     return count
   }, [urlState])
 
@@ -569,6 +599,13 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
       parts.push(name.charAt(0).toUpperCase() + name.slice(1))
     }
     if (urlState.onlyDiscounted) parts.push("On sale")
+    if (urlState.brand.trim()) {
+      const brands = urlState.brand
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+      parts.push(brands.length === 1 ? brands[0]! : `${brands.length} brands`)
+    }
     if (urlState.priceMin && urlState.priceMax) parts.push(`${urlState.priceMin}–${urlState.priceMax}€`)
     else if (urlState.priceMin) parts.push(`From ${urlState.priceMin}€`)
     else if (urlState.priceMax) parts.push(`Up to ${urlState.priceMax}€`)
@@ -587,6 +624,7 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
     const catId = parseCategoryId(urlState.category)
     if (catId) params.set("canonicalCat", String(catId))
     if (urlState.onlyDiscounted) params.set("onlyDiscounted", "true")
+    if (urlState.brand.trim()) params.set("brand", urlState.brand.trim())
     return params.toString()
   }, [urlState])
 
@@ -605,6 +643,7 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
     if (selectedPriorities.length > 0) parts.push(`Priority: ${selectedPriorities.join(", ")}`)
     if (selectedSources.length > 0) parts.push(`Source: ${selectedSources.join(", ")}`)
     if (urlState.category) parts.push(`Category: ${urlState.category}`)
+    if (urlState.brand.trim()) parts.push(`Brand: ${urlState.brand.trim()}`)
     if (urlState.onlyDiscounted) parts.push("Only discounted")
     return parts.length > 0 ? parts.join(" • ") : "No filters applied (all products)"
   }, [urlState, selectedOrigins, selectedPriorities, selectedSources])
@@ -767,7 +806,7 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
                         </div>
                       </SelectTrigger>
                       <SelectContent>
-                        {UTILITY_SORT_OPTIONS.map((option) => (
+                        {sortOptionsForSelect.map((option) => (
                           <SelectItem key={option.value} value={option.value}>
                             <div className="flex items-center gap-2">
                               <option.icon className="h-4 w-4" />
@@ -872,6 +911,36 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
                     })
                   }}
                 />
+              </AccordionContent>
+            </AccordionItem>
+
+            {/* Brand filter */}
+            <AccordionItem value="brand">
+              <AccordionTrigger className="cursor-pointer justify-between gap-2 py-2 text-sm font-medium hover:no-underline">
+                Brand
+                {localFilters.brand.trim() && (
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleClearBrand()
+                    }}
+                    className="text-muted-foreground hover:text-foreground ml-auto text-xs underline-offset-2 hover:underline"
+                  >
+                    Clear
+                  </span>
+                )}
+              </AccordionTrigger>
+              <AccordionContent className="p-px pb-3">
+                <Input
+                  placeholder="e.g. Kinder, Nestlé (comma-separated)"
+                  className="text-sm"
+                  value={localFilters.brand}
+                  onChange={(e) => handleBrandInputChange(e.target.value)}
+                  aria-label="Filter by brand names"
+                />
+                <p className="text-muted-foreground mt-1.5 text-xs">Exact store brand names; separate multiple with commas.</p>
               </AccordionContent>
             </AccordionItem>
 
@@ -1064,6 +1133,7 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
         open={mobileFiltersOpen}
         onOpenChange={setMobileFiltersOpen}
         activeFilterCount={activeFilterCount}
+        searchQueryForSort={queryInput.trim() || urlState.query.trim()}
         localFilters={localFilters}
         selectedOrigins={selectedOrigins}
         selectedPriorities={selectedPriorities}
@@ -1076,6 +1146,7 @@ export function StoreProductsShowcase({ limit = 20, children }: StoreProductsSho
         onTogglePriorityOrder={handleTogglePriorityOrder}
         onToggleAvailable={handleToggleAvailable}
         onToggleDiscounted={handleToggleDiscounted}
+        onBrandChange={handleBrandInputChange}
         onPriceRangeChange={(min, max) => {
           setLocalFilters((prev) => ({ ...prev, priceMin: min, priceMax: max }))
           debouncedUpdateUrl({ price_min: min || null, price_max: max || null, page: 1 })

--- a/src/components/products/store-products-showcase/url-state.ts
+++ b/src/components/products/store-products-showcase/url-state.ts
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { PrioritySource } from "@/types"
 import { SupermarketChain, type StoreProductsQueryParams } from "@/hooks/useStoreProducts"
-import { type SearchType, type SortByType } from "@/types/business"
+import { type SearchType, type SortByType, DEFAULT_BROWSE_SORT } from "@/types/business"
 import { buildPageTitle } from "@/lib/business/page-title"
 
 export const FILTER_DEBOUNCE_MS = 500
@@ -16,11 +16,11 @@ export const FILTER_DEBOUNCE_MS = 500
  */
 export const FILTER_CONFIG = {
   page: { key: "page", default: 1 },
-  sortBy: { key: "sort", default: "relevance" },
+  sortBy: { key: "sort", default: DEFAULT_BROWSE_SORT },
   origin: { key: "origin", default: "" },
   searchType: { key: "t", default: "any" },
   query: { key: "q", default: "" },
-  orderByPriority: { key: "priority_order", default: true },
+  orderByPriority: { key: "priority_order", default: false },
   onlyAvailable: { key: "available", default: true },
   onlyDiscounted: { key: "discounted", default: false },
   priority: { key: "priority", default: "" },
@@ -28,6 +28,7 @@ export const FILTER_CONFIG = {
   category: { key: "category", default: "" },
   priceMin: { key: "price_min", default: "" },
   priceMax: { key: "price_max", default: "" },
+  brand: { key: "brand", default: "" },
 } as const
 
 export function toSlug(name: string): string {
@@ -72,7 +73,7 @@ export function useUrlState() {
       origin: searchParams.get(FILTER_CONFIG.origin.key) ?? FILTER_CONFIG.origin.default,
       searchType: (searchParams.get(FILTER_CONFIG.searchType.key) ?? FILTER_CONFIG.searchType.default) as SearchType,
       query: searchParams.get(FILTER_CONFIG.query.key) ?? FILTER_CONFIG.query.default,
-      orderByPriority: searchParams.get(FILTER_CONFIG.orderByPriority.key) !== "false",
+      orderByPriority: searchParams.get(FILTER_CONFIG.orderByPriority.key) === "true",
       onlyAvailable: searchParams.get(FILTER_CONFIG.onlyAvailable.key) !== "false",
       onlyDiscounted: searchParams.get(FILTER_CONFIG.onlyDiscounted.key) === "true",
       priority: searchParams.get(FILTER_CONFIG.priority.key) ?? FILTER_CONFIG.priority.default,
@@ -80,6 +81,7 @@ export function useUrlState() {
       category: searchParams.get(FILTER_CONFIG.category.key) ?? FILTER_CONFIG.category.default,
       priceMin: searchParams.get(FILTER_CONFIG.priceMin.key) ?? FILTER_CONFIG.priceMin.default,
       priceMax: searchParams.get(FILTER_CONFIG.priceMax.key) ?? FILTER_CONFIG.priceMax.default,
+      brand: searchParams.get(FILTER_CONFIG.brand.key) ?? FILTER_CONFIG.brand.default,
     }),
     [searchParams],
   )
@@ -188,6 +190,16 @@ export function buildQueryParams(
     params.priceRange = {
       ...(priceMin != null && !isNaN(priceMin) ? { min: priceMin } : {}),
       ...(priceMax != null && !isNaN(priceMax) ? { max: priceMax } : {}),
+    }
+  }
+
+  if (urlState.brand.trim()) {
+    const names = urlState.brand
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+    if (names.length > 0) {
+      params.brand = { names }
     }
   }
 

--- a/src/hooks/useStoreProducts.ts
+++ b/src/hooks/useStoreProducts.ts
@@ -61,6 +61,11 @@ function paramsToSearchParams(params: StoreProductsQueryParams): Record<string, 
     searchParams.canonicalCat = String(params.canonicalCategory.categoryId)
   }
 
+  // Brand (comma-separated exact names)
+  if (params.brand?.names?.length) {
+    searchParams.brand = params.brand.names.join(",")
+  }
+
   // Price range
   if (params.priceRange?.min != null) {
     searchParams.priceMin = String(params.priceRange.min)

--- a/src/lib/business/filters.ts
+++ b/src/lib/business/filters.ts
@@ -15,7 +15,7 @@ import {
 } from "lucide-react"
 
 export const UTILITY_SORT_OPTIONS = [
-  { label: "Most Relevant", value: "relevance", icon: SquareStarIcon },
+  { label: "Best match (search)", value: "relevance", icon: SquareStarIcon },
   { label: "Name: A to Z", value: "a-z", icon: ArrowDownAZ },
   { label: "Name: Z to A", value: "z-a", icon: ArrowUpAZ },
   { label: "Price: High to Low", value: "price-high-low", icon: ArrowUpWideNarrowIcon },
@@ -27,7 +27,7 @@ export const UTILITY_SORT_OPTIONS = [
 ] as const
 
 export const ALL_SORT_LABELS: Record<string, { label: string; icon: typeof ClockArrowDown }> = {
-  relevance: { label: "Most Relevant", icon: SquareStarIcon },
+  relevance: { label: "Best match (search)", icon: SquareStarIcon },
   "updated-newest": { label: "Recently Updated", icon: ClockArrowDown },
   "updated-oldest": { label: "Least Updated", icon: ClockArrowUp },
   "created-newest": { label: "Recently Added", icon: CalendarArrowDown },
@@ -44,7 +44,7 @@ export const ALL_SORT_LABELS: Record<string, { label: string; icon: typeof Clock
 export const SORT_OPTIONS_GROUPS = [
   {
     label: "Search",
-    options: [{ label: "Most Relevant", value: "relevance", icon: SquareStarIcon }],
+    options: [{ label: "Best match (search)", value: "relevance", icon: SquareStarIcon }],
   },
   {
     label: "Price Intelligence",

--- a/src/lib/queries/store-products/index.ts
+++ b/src/lib/queries/store-products/index.ts
@@ -45,6 +45,7 @@ export type {
   CategoryFilter,
   CategoryTuple,
   CanonicalCategoryFilter,
+  BrandFilter,
   OriginFilter,
   PriorityFilter,
   SourceFilter,

--- a/src/lib/queries/store-products/query.ts
+++ b/src/lib/queries/store-products/query.ts
@@ -150,6 +150,7 @@ export async function queryStoreProducts(
   query = applyPriorityFilter(query, params, flags)
   query = applyOriginFilter(query, params)
   query = applyCategoryFilter(query, params)
+  query = applyBrandFilter(query, params)
   query = applySearchFilter(query, params)
 
   if (flags.onlyDiscounted) {
@@ -267,6 +268,7 @@ async function queryWithRelevanceRanking(
   query = applyPriorityFilter(query, params, flags)
   query = applyOriginFilter(query, params)
   query = applyCategoryFilter(query, params)
+  query = applyBrandFilter(query, params)
 
   if (flags.onlyDiscounted) {
     query = query.gt("discount", 0)
@@ -359,6 +361,7 @@ async function queryWithIlikeFallback(
   query = applyPriorityFilter(query, params, flags)
   query = applyOriginFilter(query, params)
   query = applyCategoryFilter(query, params)
+  query = applyBrandFilter(query, params)
   query = applyIlikeSearchFallback(query, params)
 
   if (flags.onlyDiscounted) {
@@ -426,6 +429,12 @@ async function queryWithIlikeFallback(
 // ============================================================================
 // Filter Helper Functions
 // ============================================================================
+
+function applyBrandFilter<Q extends { [key: string]: any }>(query: Q, params: StoreProductsQueryParams): Q {
+  const names = params.brand?.names?.map((n) => n.trim()).filter((n) => n.length > 0) ?? []
+  if (names.length === 0) return query
+  return query.in("brand", names)
+}
 
 function applyPriorityFilter<Q extends { [key: string]: any }>(
   query: Q,
@@ -836,6 +845,7 @@ export async function getMatchingProductsCount(
   query = applyPriorityFilter(query, params, flags)
   query = applyOriginFilter(query, params)
   query = applyCategoryFilter(query, params)
+  query = applyBrandFilter(query, params)
   query = applySearchFilter(query, params)
   query = applySourceFilter(query, params)
 
@@ -902,6 +912,7 @@ export async function getMatchingProductsWithDistribution(
     // Apply all filters EXCEPT priority (we want to see all priorities in the distribution)
     query = applyOriginFilter(query, params)
     query = applyCategoryFilter(query, params)
+    query = applyBrandFilter(query, params)
     query = applySearchFilter(query, params)
     query = applySourceFilter(query, params)
 
@@ -987,6 +998,7 @@ export async function bulkUpdatePriority(params: BulkPriorityUpdateParams): Prom
     query = applyPriorityFilter(query, params.filters, flags)
     query = applyOriginFilter(query, params.filters)
     query = applyCategoryFilter(query, params.filters)
+    query = applyBrandFilter(query, params.filters)
     query = applySearchFilter(query, params.filters)
     query = applySourceFilter(query, params.filters)
 

--- a/src/lib/queries/store-products/types.ts
+++ b/src/lib/queries/store-products/types.ts
@@ -1,5 +1,5 @@
 import type { SearchType, SortByType } from "@/types/business"
-import { SupermarketChain } from "@/types/business"
+import { SupermarketChain, DEFAULT_BROWSE_SORT } from "@/types/business"
 import type { StoreProduct, PrioritySource } from "@/types"
 import { createClient } from "@/lib/supabase/server"
 
@@ -135,6 +135,13 @@ export interface CanonicalCategoryFilter {
 }
 
 /**
+ * Brand filter — exact match on `store_products.brand` (OR within the list).
+ */
+export interface BrandFilter {
+  names: string[]
+}
+
+/**
  * Sorting options
  */
 export interface SortOptions {
@@ -206,6 +213,9 @@ export interface StoreProductsQueryParams {
   /** Price range filter */
   priceRange?: PriceRangeFilter
 
+  /** Filter by exact brand name(s) */
+  brand?: BrandFilter
+
   /** Additional filter flags */
   flags?: FilterFlags
 
@@ -267,7 +277,7 @@ export const DEFAULT_PAGINATION: PaginationOptions = {
 }
 
 export const DEFAULT_SORT: SortOptions = {
-  sortBy: "a-z",
+  sortBy: DEFAULT_BROWSE_SORT,
   prioritizeByPriority: false,
 }
 
@@ -329,6 +339,11 @@ export function generateQueryKey(params: StoreProductsQueryParams): QueryKeyValu
       .join(";")
   }
 
+  const getBrandKey = (): QueryKeyValue => {
+    if (!params.brand?.names?.length) return null
+    return [...params.brand.names].sort().join("|")
+  }
+
   return [
     "storeProducts",
     // Search
@@ -346,6 +361,8 @@ export function generateQueryKey(params: StoreProductsQueryParams): QueryKeyValu
     params.canonicalCategory?.categoryId ?? null,
     // Origin
     getOriginKey(),
+    // Brand
+    getBrandKey(),
     // Priority
     getPriorityKey(),
     // Source

--- a/src/types/business.ts
+++ b/src/types/business.ts
@@ -29,7 +29,7 @@ export const STORE_COLORS_SECONDARY: Record<number, string> = {
 }
 
 export const SORT_LABELS: Record<string, string> = {
-  relevance: "Most Relevant",
+  relevance: "Best match (search)",
   "a-z": "A to Z",
   "z-a": "Z to A",
   "price-low-high": "Cheapest",
@@ -70,10 +70,15 @@ export const sortByTypes = [
   "only-nulls",
 ] as const
 
+export type SortByType = (typeof sortByTypes)[number]
+
+/** Default /products `sort` when the URL omits it (browse without an active search). */
+export const DEFAULT_BROWSE_SORT: SortByType = "updated-newest"
+
 export const sortTypesLabels: {
   [key in SortByType]: string
 } = {
-  relevance: "Most Relevant",
+  relevance: "Best match (search)",
   "a-z": "A to Z",
   "z-a": "Z to A",
   "price-low-high": "High to Low",
@@ -90,10 +95,8 @@ export const sortTypesLabels: {
 
 export const getSortByType = (sortBy: string) => {
   if (sortByTypes.includes(sortBy as SortByType)) return sortBy as SortByType
-  return "a-z" as SortByType
+  return DEFAULT_BROWSE_SORT
 }
-
-export type SortByType = (typeof sortByTypes)[number]
 
 export const RANGES = ["1W", "2W", "1M", "3M", "6M", "1Y", "Max"] as const
 export type DateRange = (typeof RANGES)[number]


### PR DESCRIPTION
## Summary
- Align server/client default sort to `updated-newest` via `DEFAULT_BROWSE_SORT`; fix prefetch/query-key parity.
- Rename misleading "Most Relevant" to **Best match (search)**; hide relevance sort until a query exists; normalize `sort=relevance` without `q`.
- Default **Order by priority** off (`priority_order` only when `true`).
- Add **brand** URL/API/query filter (comma-separated exact names) + sidebar/mobile UI; brand links on product cards.
- OG + products page metadata include brand/price params where applicable.

## Notes
- API always applies explicit sort (defaults to browse sort when omitted).

Made with [Cursor](https://cursor.com)