### PR TITLE
Price volatility stats, listing quality gates, and price_change_pct correctness

### DIFF
--- a/src/app/api/admin/alerts/price-drops/route.ts
+++ b/src/app/api/admin/alerts/price-drops/route.ts
@@ -5,6 +5,7 @@ import { priceDropAlertHtml, priceDropAlertSubject } from "@/lib/email/templates
 import { siteConfig } from "@/lib/config"
 import { STORE_NAMES } from "@/types/business"
 import { generateProductSlug } from "@/lib/business/product"
+import { priceBeforeFromChangeRatio, priceChangeRatioToPercentPoints } from "@/lib/business/price-change"
 
 export const maxDuration = 60
 
@@ -58,13 +59,25 @@ export async function POST() {
       available: boolean
     }
 
-    if (!product || !product.available || !product.price_change_pct || product.price_change_pct >= 0) continue
+    if (
+      !product ||
+      !product.available ||
+      product.price_change_pct == null ||
+      product.price_change_pct >= 0 ||
+      product.price == null ||
+      product.price <= 0
+    )
+      continue
 
-    const changePct = Math.abs(product.price_change_pct)
+    const changeRatioAbs = Math.abs(product.price_change_pct)
 
     if (sub.threshold_type === "any_drop") {
       alertsToSend.push({ subscription: sub, product: { ...product, price_change_pct: product.price_change_pct } })
-    } else if (sub.threshold_type === "percentage" && sub.threshold_value && changePct >= sub.threshold_value) {
+    } else if (
+      sub.threshold_type === "percentage" &&
+      sub.threshold_value != null &&
+      changeRatioAbs >= sub.threshold_value
+    ) {
       alertsToSend.push({ subscription: sub, product: { ...product, price_change_pct: product.price_change_pct } })
     } else if (sub.threshold_type === "target_price" && sub.threshold_value && product.price <= sub.threshold_value) {
       alertsToSend.push({ subscription: sub, product: { ...product, price_change_pct: product.price_change_pct } })
@@ -100,7 +113,8 @@ export async function POST() {
 
     const userName = nameMap.get(alert.subscription.user_id) || "there"
     const storeName = STORE_NAMES[alert.product.origin_id] || "Unknown Store"
-    const oldPrice = alert.product.price / (1 + alert.product.price_change_pct / 100)
+    const oldPrice = priceBeforeFromChangeRatio(alert.product.price, alert.product.price_change_pct)
+    if (oldPrice == null) continue
     const slug = generateProductSlug(alert.product)
     const productUrl = `${siteConfig.url}/products/${alert.product.id}-${slug}`
 
@@ -108,7 +122,10 @@ export async function POST() {
       await resend.emails.send({
         from: FROM_EMAIL,
         to: email,
-        subject: priceDropAlertSubject(alert.product.name, alert.product.price_change_pct),
+        subject: priceDropAlertSubject(
+          alert.product.name,
+          priceChangeRatioToPercentPoints(alert.product.price_change_pct),
+        ),
         html: priceDropAlertHtml({
           userName,
           productName: alert.product.name,
@@ -116,7 +133,7 @@ export async function POST() {
           storeName,
           oldPrice,
           newPrice: alert.product.price,
-          changePercent: alert.product.price_change_pct,
+          changePercent: priceChangeRatioToPercentPoints(alert.product.price_change_pct),
           productUrl,
         }),
       })

--- a/src/app/api/admin/price-stats-worker/route.ts
+++ b/src/app/api/admin/price-stats-worker/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createAdminClient } from "@/lib/supabase/server"
+
+export const maxDuration = 120
+
+const DEFAULT_BATCH = 2000
+const MAX_LOOPS = 25
+
+/**
+ * GET /api/admin/price-stats-worker — cron: refresh denormalized price volatility columns in batches.
+ * POST — manual trigger (e.g. QStash).
+ */
+async function handler(req: NextRequest) {
+  const triggeredBy = req.method === "GET" ? "cron" : "manual"
+  const authHeader = req.headers.get("authorization")
+  if (process.env.CRON_SECRET && authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  try {
+    const supabase = createAdminClient()
+    const urlBatch = req.nextUrl.searchParams.get("batch")
+    const batchSize = urlBatch ? Math.min(5000, Math.max(200, parseInt(urlBatch, 10) || DEFAULT_BATCH)) : DEFAULT_BATCH
+
+    let totalProcessed = 0
+    let loops = 0
+    const started = performance.now()
+
+    while (loops < MAX_LOOPS) {
+      const { data, error } = await supabase.rpc("refresh_store_product_price_stats_batch", {
+        p_batch_size: batchSize,
+      })
+
+      if (error) {
+        console.error("[price-stats-worker] RPC error:", error.message)
+        return NextResponse.json({ error: error.message }, { status: 500 })
+      }
+
+      const payload = data as { processed?: number } | null
+      const processed = typeof payload?.processed === "number" ? payload.processed : 0
+      totalProcessed += processed
+      loops++
+
+      if (processed === 0) break
+    }
+
+    const elapsed = Math.round(performance.now() - started)
+    console.log(
+      `[price-stats-worker] ${triggeredBy}: processed ${totalProcessed} rows in ${loops} batch(es), ${elapsed}ms`,
+    )
+
+    return NextResponse.json({
+      ok: true,
+      triggered_by: triggeredBy,
+      total_processed: totalProcessed,
+      batches_run: loops,
+      duration_ms: elapsed,
+    })
+  } catch (err) {
+    console.error("[price-stats-worker] Unhandled error:", err)
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 },
+    )
+  }
+}
+
+export const GET = handler
+export const POST = handler

--- a/src/app/api/alerts/route.ts
+++ b/src/app/api/alerts/route.ts
@@ -40,10 +40,15 @@ export async function POST(req: NextRequest) {
   }
 
   const body = await req.json()
-  const { store_product_id, threshold_type = "any_drop", threshold_value } = body
+  const { store_product_id, threshold_type = "any_drop", threshold_value: rawThreshold } = body
 
   if (!store_product_id) {
     return NextResponse.json({ error: "store_product_id is required" }, { status: 400 })
+  }
+
+  let threshold_value: number | null = rawThreshold ?? null
+  if (threshold_type === "percentage" && threshold_value != null && threshold_value > 1) {
+    threshold_value = threshold_value / 100
   }
 
   const { data, error } = await supabase
@@ -53,7 +58,7 @@ export async function POST(req: NextRequest) {
         user_id: user.id,
         store_product_id,
         threshold_type,
-        threshold_value: threshold_value ?? null,
+        threshold_value,
         is_active: true,
         updated_at: new Date().toISOString(),
       },

--- a/src/app/api/scrape/scheduler/route.ts
+++ b/src/app/api/scrape/scheduler/route.ts
@@ -105,7 +105,7 @@ export async function GET(req: NextRequest) {
     // Fetch wider column set so the batch worker doesn't need to re-read each product.
     // The extra fields are passed through QStash to eliminate per-product SELECTs.
     const SCHEDULER_COLUMNS =
-      "id, url, name, origin_id, priority, priority_source, barcode, brand, image, pack, category, category_2, category_3, created_at, updated_at"
+      "id, url, name, origin_id, priority, priority_source, barcode, brand, image, pack, category, category_2, category_3, created_at, updated_at, price_stats_cv_ln_90d"
 
     const {
       data: products,
@@ -211,7 +211,11 @@ export async function GET(req: NextRequest) {
         const thresholdHours = PRIORITY_REFRESH_HOURS[product.priority ?? 0] ?? 24
         const updatedAt = product.updated_at ? new Date(product.updated_at) : new Date(0) // Never scraped = very old
         const hoursAgo = (now.getTime() - updatedAt.getTime()) / (1000 * 60 * 60)
-        const urgencyScore = hoursAgo / thresholdHours
+        const baseUrgency = hoursAgo / thresholdHours
+        const cv = product.price_stats_cv_ln_90d
+        const volatilityBoost =
+          typeof cv === "number" && Number.isFinite(cv) && cv > 1e-9 ? Math.min(0.35, cv / 0.12) : 0
+        const urgencyScore = baseUrgency * (1 + volatilityBoost)
 
         return {
           ...product,

--- a/src/app/api/user/stats/route.ts
+++ b/src/app/api/user/stats/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
+import { priceBeforeFromChangeRatio } from "@/lib/business/price-change"
 
 /**
  * User stats & savings estimate.
@@ -44,10 +45,17 @@ export async function GET() {
 
   for (const fav of favorites) {
     const product = fav.store_products as unknown as { price: number; price_change_pct: number | null }
-    if (product?.price_change_pct && product.price_change_pct < 0) {
-      const priceBefore = product.price / (1 + product.price_change_pct / 100)
-      estimatedSavings += priceBefore - product.price
-      productsWithDrops++
+    if (
+      product?.price != null &&
+      product.price > 0 &&
+      product.price_change_pct != null &&
+      product.price_change_pct < 0
+    ) {
+      const priceBefore = priceBeforeFromChangeRatio(product.price, product.price_change_pct)
+      if (priceBefore != null) {
+        estimatedSavings += priceBefore - product.price
+        productsWithDrops++
+      }
     }
   }
 

--- a/src/components/products/StoreProductCard.tsx
+++ b/src/components/products/StoreProductCard.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils"
 import { imagePlaceholder } from "@/lib/business/data"
 import { formatRelativeTime } from "@/lib/business/chart"
 import { discountValueToPercentage, generateProductPath } from "@/lib/business/product"
+import { PLAUSIBLE_MAX_PRICE_CHANGE_MAGNITUDE } from "@/lib/business/price-change"
 
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
 import { Badge, badgeVariants } from "@/components/ui/badge"
@@ -100,10 +101,13 @@ export function StoreProductCard({ sp, imagePriority = false, favoritedAt, showB
       <SupermarketChainBadge originId={sp?.origin_id} variant="logoSmall" />
     </span>
   )
-  const isPriceNotSet = !sp.price_recommended && !sp.price
+  const hasUnitPrice = sp.price_per_major_unit != null && sp.major_unit
+  const isPriceNotSet = !sp.price_recommended && !sp.price && !hasUnitPrice
   const hasDiscount = sp.price_recommended && sp.price && sp.price_recommended !== sp.price
   const isNormalPrice =
     (!sp.price_recommended && sp.price) || (sp.price_recommended && sp.price && sp.price_recommended === sp.price)
+  const isPriceMissingWithReference =
+    !sp.price && (sp.price_recommended != null || (sp.discount != null && sp.discount > 0))
 
   const categoryText = sp.category
     ? `${sp.category}${sp.category_2 ? ` > ${sp.category_2}` : ""}${sp.category_3 ? ` > ${sp.category_3}` : ""}`
@@ -350,6 +354,18 @@ export function StoreProductCard({ sp, imagePriority = false, favoritedAt, showB
               </div>
             ) : null}
 
+            {isPriceMissingWithReference ? (
+              <div className="flex flex-col gap-0.5">
+                <span className="text-muted-foreground text-sm font-medium">Preço indisponível</span>
+                {hasUnitPrice ? (
+                  <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-200">
+                    {sp.price_per_major_unit!.toFixed(2)}€/
+                    {sp.major_unit!.startsWith("/") ? sp.major_unit!.slice(1) : sp.major_unit}
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
+
             {isPriceNotSet ? <span className="text-lg font-bold text-zinc-700 dark:text-zinc-200">--.--€</span> : null}
           </div>
 
@@ -554,6 +570,7 @@ const PRICE_CHANGE_THRESHOLD = 0.01
 
 function PriceChangeBadge({ pct }: { pct: number | null | undefined }) {
   if (pct == null || Math.abs(pct) < PRICE_CHANGE_THRESHOLD) return null
+  if (Math.abs(pct) > PLAUSIBLE_MAX_PRICE_CHANGE_MAGNITUDE) return null
 
   const isSignificant = Math.abs(pct) >= 0.05
   const isNegative = pct < 0

--- a/src/lib/business/filters.ts
+++ b/src/lib/business/filters.ts
@@ -37,6 +37,7 @@ export const ALL_SORT_LABELS: Record<string, { label: string; icon: typeof Clock
   "price-high-low": { label: "Price: High to Low", icon: ArrowUpWideNarrowIcon },
   "price-low-high": { label: "Price: Low to High", icon: ArrowDownWideNarrowIcon },
   "price-drop": { label: "Biggest Price Drops", icon: TrendingDownIcon },
+  "price-drop-smart": { label: "Price Drops (weighted)", icon: TrendingDownIcon },
   "price-increase": { label: "Biggest Price Increases", icon: TrendingUpIcon },
   "best-discount": { label: "Best Discounts", icon: TicketPercentIcon },
 }
@@ -50,6 +51,7 @@ export const SORT_OPTIONS_GROUPS = [
     label: "Price Intelligence",
     options: [
       { label: "Biggest Price Drops", value: "price-drop", icon: TrendingDownIcon },
+      { label: "Price Drops (weighted)", value: "price-drop-smart", icon: TrendingDownIcon },
       { label: "Biggest Price Increases", value: "price-increase", icon: TrendingUpIcon },
       { label: "Best Discounts", value: "best-discount", icon: TicketPercentIcon },
     ],

--- a/src/lib/business/hero.ts
+++ b/src/lib/business/hero.ts
@@ -38,9 +38,12 @@ export async function getHeroProducts(): Promise<HeroProduct[]> {
 
     const { data, error } = await supabase
       .from("store_products")
-      .select("id, name, image, origin_id, brand, price, price_recommended, discount")
+      .select("id, name, image, origin_id, brand, price, price_recommended, discount, available")
       .in("id", HERO_PRODUCT_IDS)
       .not("image", "is", null)
+      .eq("available", true)
+      .not("price", "is", null)
+      .gt("price", 0)
 
     if (error || !data) return []
 

--- a/src/lib/business/price-change.ts
+++ b/src/lib/business/price-change.ts
@@ -1,0 +1,21 @@
+/**
+ * `store_products.price_change_pct` from `upsert_price_point` is a decimal ratio:
+ * (new_price - old_price) / old_price, e.g. -0.25 means −25%.
+ */
+
+/** Cap for listing "price drop" / giant discount rows; relative change ratio (0.65 => 65%). */
+export const PLAUSIBLE_MAX_PRICE_CHANGE_MAGNITUDE = 0.65
+
+/** Default window for "recent" price moves on entry-point sorts (days). */
+export const DEFAULT_LISTING_PRICE_CHANGE_RECENCY_DAYS = 14
+
+/** Previous price before the last recorded change (undefined if ratio is invalid). */
+export function priceBeforeFromChangeRatio(newPrice: number, changeRatio: number): number | undefined {
+  if (newPrice <= 0 || changeRatio <= -1 || !Number.isFinite(changeRatio)) return undefined
+  return newPrice / (1 + changeRatio)
+}
+
+/** Human-facing percent points (e.g. 25 for −25% when ratio is −0.25). */
+export function priceChangeRatioToPercentPoints(changeRatio: number): number {
+  return changeRatio * 100
+}

--- a/src/lib/queries/deals.ts
+++ b/src/lib/queries/deals.ts
@@ -1,4 +1,8 @@
 import { createClient } from "@/lib/supabase/server"
+import {
+  DEFAULT_LISTING_PRICE_CHANGE_RECENCY_DAYS,
+  PLAUSIBLE_MAX_PRICE_CHANGE_MAGNITUDE,
+} from "@/lib/business/price-change"
 
 export interface DealProduct {
   id: number
@@ -47,12 +51,21 @@ export async function getDeals(options?: { originId?: number; limit?: number }):
   const supabase = createClient()
   const limit = options?.limit ?? 24
 
+  const dropRecencyCutoff = new Date(
+    Date.now() - DEFAULT_LISTING_PRICE_CHANGE_RECENCY_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString()
+
   let priceDropsQuery = supabase
     .from("store_products")
     .select(DEAL_COLUMNS)
     .eq("available", true)
     .not("name", "is", null)
+    .not("price", "is", null)
+    .gt("price", 0)
+    .not("last_price_change_at", "is", null)
+    .gte("last_price_change_at", dropRecencyCutoff)
     .lt("price_change_pct", 0)
+    .gte("price_change_pct", -PLAUSIBLE_MAX_PRICE_CHANGE_MAGNITUDE)
     .order("price_change_pct", { ascending: true })
     .limit(limit)
 
@@ -61,7 +74,10 @@ export async function getDeals(options?: { originId?: number; limit?: number }):
     .select(DEAL_COLUMNS)
     .eq("available", true)
     .not("name", "is", null)
+    .not("price", "is", null)
+    .gt("price", 0)
     .gt("discount", 0)
+    .lte("discount", PLAUSIBLE_MAX_PRICE_CHANGE_MAGNITUDE)
     .order("discount", { ascending: false })
     .limit(limit)
 

--- a/src/lib/queries/store-products/query.ts
+++ b/src/lib/queries/store-products/query.ts
@@ -2,10 +2,70 @@ import { createClient } from "@/lib/supabase/server"
 import { fetchAll } from "@/lib/supabase/fetch-all"
 import { withTimeout } from "@/lib/resilience"
 import type { SupabaseClient } from "./types"
-import type { StoreProductsQueryParams, StoreProductsQueryResult, StoreProductWithMeta, PaginationMeta } from "./types"
+import type {
+  StoreProductsQueryParams,
+  StoreProductsQueryResult,
+  StoreProductWithMeta,
+  PaginationMeta,
+  FilterFlags,
+} from "./types"
 import { DEFAULT_PAGINATION, DEFAULT_SORT, DEFAULT_FLAGS } from "./types"
+import {
+  DEFAULT_LISTING_PRICE_CHANGE_RECENCY_DAYS,
+  PLAUSIBLE_MAX_PRICE_CHANGE_MAGNITUDE,
+} from "@/lib/business/price-change"
 
 const SUPABASE_QUERY_TIMEOUT_MS = parseInt(process.env.SUPABASE_QUERY_TIMEOUT_MS || "15000", 10)
+
+const SORTS_REQUIRING_NON_NULL_PRICE = new Set([
+  "price-drop",
+  "price-drop-smart",
+  "price-increase",
+  "best-discount",
+])
+
+function mergeListingFlags(
+  sortBy: string,
+  userFlags: typeof DEFAULT_FLAGS & FilterFlags,
+): typeof DEFAULT_FLAGS & FilterFlags {
+  const base = { ...DEFAULT_FLAGS, ...userFlags }
+  if (SORTS_REQUIRING_NON_NULL_PRICE.has(sortBy)) {
+    return { ...base, requireNonNullPrice: userFlags.requireNonNullPrice !== false }
+  }
+  return base
+}
+
+function applyListingQualityFilters<Q extends { [key: string]: any }>(
+  query: Q,
+  sortBy: string,
+  flags: typeof DEFAULT_FLAGS & FilterFlags,
+): Q {
+  let q = query
+  if (flags.requireNonNullPrice) {
+    q = q.not("price", "is", null).gt("price", 0)
+  }
+  if (sortBy === "price-drop" || sortBy === "price-drop-smart") {
+    const cutoff = new Date(
+      Date.now() - DEFAULT_LISTING_PRICE_CHANGE_RECENCY_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString()
+    q = q.not("last_price_change_at", "is", null).gte("last_price_change_at", cutoff).lt("price_change_pct", 0)
+    q = q.gte("price_change_pct", -PLAUSIBLE_MAX_PRICE_CHANGE_MAGNITUDE)
+    if (sortBy === "price-drop-smart") {
+      q = q.not("price_drop_smart_score", "is", null)
+    }
+  }
+  if (sortBy === "price-increase") {
+    const cutoff = new Date(
+      Date.now() - DEFAULT_LISTING_PRICE_CHANGE_RECENCY_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString()
+    q = q.not("last_price_change_at", "is", null).gte("last_price_change_at", cutoff).gt("price_change_pct", 0)
+    q = q.lte("price_change_pct", PLAUSIBLE_MAX_PRICE_CHANGE_MAGNITUDE)
+  }
+  if (sortBy === "best-discount") {
+    q = q.gt("discount", 0).lte("discount", PLAUSIBLE_MAX_PRICE_CHANGE_MAGNITUDE)
+  }
+  return q
+}
 
 // Explicit column lists to avoid SELECT * egress overhead
 const LISTING_COLUMNS = [
@@ -32,6 +92,10 @@ const LISTING_COLUMNS = [
   "updated_at",
   "price_change_pct",
   "last_price_change_at",
+  "price_stats_obs_90d",
+  "price_stats_cv_ln_90d",
+  "price_drop_smart_score",
+  "price_stats_updated_at",
 ].join(", ")
 
 const LISTING_COLUMNS_CANONICAL = [
@@ -105,7 +169,7 @@ export async function queryStoreProducts(
 
   const pagination = { ...DEFAULT_PAGINATION, ...params.pagination }
   const sort = { ...DEFAULT_SORT, ...params.sort }
-  const flags = { ...DEFAULT_FLAGS, ...params.flags }
+  const flags = mergeListingFlags(sort.sortBy, { ...DEFAULT_FLAGS, ...params.flags })
 
   // Route to relevance-ranked RPC when searching with relevance sort
   const hasSearchQuery = !!params.search?.query && sanitizeSearchQuery(params.search.query).length > 0
@@ -161,6 +225,7 @@ export async function queryStoreProducts(
   }
 
   query = applySourceFilter(query, params)
+  query = applyListingQualityFilters(query, sort.sortBy, flags)
 
   if (params.priceRange?.min != null) {
     query = query.gte("price", params.priceRange.min)
@@ -254,7 +319,7 @@ async function queryWithRelevanceRanking(
   supabase: SupabaseClient,
   pagination: { page: number; limit: number },
   sort: { sortBy: string; prioritizeByPriority?: boolean },
-  flags: typeof DEFAULT_FLAGS,
+  flags: typeof DEFAULT_FLAGS & FilterFlags,
 ): Promise<StoreProductsQueryResult> {
   const queryText = sanitizeSearchQuery(params.search!.query)
   const offset = (pagination.page - 1) * pagination.limit
@@ -278,6 +343,7 @@ async function queryWithRelevanceRanking(
   }
 
   query = applySourceFilter(query, params)
+  query = applyListingQualityFilters(query, sort.sortBy, flags)
 
   if (params.priceRange?.min != null) {
     query = query.gte("price", params.priceRange.min)
@@ -348,9 +414,10 @@ async function queryWithIlikeFallback(
   supabase: SupabaseClient,
   pagination: { page: number; limit: number },
   sort: { sortBy: string; prioritizeByPriority?: boolean },
-  flags: typeof DEFAULT_FLAGS,
+  flags: typeof DEFAULT_FLAGS & FilterFlags,
 ): Promise<StoreProductsQueryResult> {
   const offset = (pagination.page - 1) * pagination.limit
+  const effectiveSort = sort.sortBy === "relevance" ? "a-z" : sort.sortBy
 
   let query = supabase.from("store_products").select(LISTING_COLUMNS)
 
@@ -372,6 +439,7 @@ async function queryWithIlikeFallback(
   }
 
   query = applySourceFilter(query, params)
+  query = applyListingQualityFilters(query, effectiveSort, flags)
 
   if (params.priceRange?.min != null) {
     query = query.gte("price", params.priceRange.min)
@@ -383,7 +451,7 @@ async function queryWithIlikeFallback(
   if (sort.prioritizeByPriority) {
     query = query.order("priority", { ascending: false, nullsFirst: false })
   }
-  query = applySorting(query, sort.sortBy === "relevance" ? "a-z" : sort.sortBy)
+  query = applySorting(query, effectiveSort)
 
   query = query.range(offset, offset + pagination.limit)
 
@@ -737,6 +805,10 @@ function applySorting<Q extends { [key: string]: any }>(query: Q, sortBy: string
       return query.order("updated_at", { ascending: true, nullsFirst: true })
     case "price-drop":
       return query.order("price_change_pct", { ascending: true, nullsFirst: false })
+    case "price-drop-smart":
+      return query
+        .order("price_drop_smart_score", { ascending: false, nullsFirst: false })
+        .order("price_change_pct", { ascending: true, nullsFirst: false })
     case "price-increase":
       return query.order("price_change_pct", { ascending: false, nullsFirst: false })
     case "best-discount":
@@ -817,7 +889,8 @@ export async function getMatchingProductsCount(
   params: StoreProductsQueryParams,
 ): Promise<{ count: number; error: { message: string } | null }> {
   const supabase = createClient()
-  const flags = { ...DEFAULT_FLAGS, ...params.flags }
+  const sortBy = params.sort?.sortBy ?? DEFAULT_SORT.sortBy
+  const flags = mergeListingFlags(sortBy, { ...DEFAULT_FLAGS, ...params.flags })
 
   // Determine which table/view to use based on canonical category filter
   const useCanonicalView = !!params.canonicalCategory?.categoryId
@@ -848,6 +921,7 @@ export async function getMatchingProductsCount(
   query = applyBrandFilter(query, params)
   query = applySearchFilter(query, params)
   query = applySourceFilter(query, params)
+  query = applyListingQualityFilters(query, sortBy, flags)
 
   if (flags.onlyDiscounted) {
     query = query.gt("discount", 0)
@@ -884,7 +958,8 @@ export async function getMatchingProductsWithDistribution(
   params: StoreProductsQueryParams,
 ): Promise<PriorityDistributionResult> {
   const supabase = createClient()
-  const flags = { ...DEFAULT_FLAGS, ...params.flags }
+  const sortBy = params.sort?.sortBy ?? DEFAULT_SORT.sortBy
+  const flags = mergeListingFlags(sortBy, { ...DEFAULT_FLAGS, ...params.flags })
 
   // Determine which table/view to use based on canonical category filter
   const useCanonicalView = !!params.canonicalCategory?.categoryId
@@ -915,6 +990,7 @@ export async function getMatchingProductsWithDistribution(
     query = applyBrandFilter(query, params)
     query = applySearchFilter(query, params)
     query = applySourceFilter(query, params)
+    query = applyListingQualityFilters(query, sortBy, flags)
 
     if (flags.onlyDiscounted) {
       query = query.gt("discount", 0)

--- a/src/lib/queries/store-products/types.ts
+++ b/src/lib/queries/store-products/types.ts
@@ -175,6 +175,11 @@ export interface FilterFlags {
   onlyAvailable?: boolean
   /** Use minimal column set for OG/preview (id, origin_id, name, brand, price, discount, image) */
   minimalSelectForPreview?: boolean
+  /**
+   * When true, exclude rows with null price (browse-quality listings).
+   * Default true for sorts that need a display price.
+   */
+  requireNonNullPrice?: boolean
 }
 
 // ============================================================================

--- a/src/lib/scrapers/base.ts
+++ b/src/lib/scrapers/base.ts
@@ -7,6 +7,9 @@ import { fetchHtml, parseHtml, transformRawProduct, extractPriorityInfo, cleanUr
  * Abstract base class for all store scrapers
  * Handles common logic: fetching, error handling, transformation
  * Subclasses only need to implement the extraction logic
+ *
+ * Ingest quality: rely on last_http_status + explicit error/not_found returns;
+ * soft 404s need per-origin isSoftNotFound; partial parses should not upsert a valid-looking price.
  */
 export abstract class BaseProductScraper implements StoreScraper {
   abstract readonly originId: StoreOrigin

--- a/src/types/business.ts
+++ b/src/types/business.ts
@@ -39,6 +39,7 @@ export const SORT_LABELS: Record<string, string> = {
   "updated-newest": "Recently Updated",
   "updated-oldest": "Least Updated",
   "price-drop": "Price Drops",
+  "price-drop-smart": "Price Drops (weighted)",
   "price-increase": "Price Increases",
   "best-discount": "Best Discounts",
 }
@@ -65,6 +66,7 @@ export const sortByTypes = [
   "updated-newest",
   "updated-oldest",
   "price-drop",
+  "price-drop-smart",
   "price-increase",
   "best-discount",
   "only-nulls",
@@ -88,6 +90,7 @@ export const sortTypesLabels: {
   "updated-newest": "Recently Updated",
   "updated-oldest": "Least Recently",
   "price-drop": "Biggest Price Drops",
+  "price-drop-smart": "Price drops (history-weighted)",
   "price-increase": "Biggest Price Increases",
   "best-discount": "Best Discounts",
   "only-nulls": "Invalid products",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,6 +89,10 @@ export interface StoreProduct {
   canonical_product_id?: number | null
   price_change_pct?: number | null
   last_price_change_at?: string | null
+  price_stats_obs_90d?: number | null
+  price_stats_cv_ln_90d?: number | null
+  price_stats_updated_at?: string | null
+  price_drop_smart_score?: number | null
 }
 
 export interface StoreProductWithSimilarity extends StoreProduct {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -377,8 +377,12 @@ export type Database = {
           pack: string | null
           price: number | null
           price_change_pct: number | null
+          price_drop_smart_score: number | null
           price_per_major_unit: number | null
           price_recommended: number | null
+          price_stats_cv_ln_90d: number | null
+          price_stats_obs_90d: number | null
+          price_stats_updated_at: string | null
           priority: number | null
           priority_source: Database["public"]["Enums"]["priority_source_type"] | null
           priority_updated_at: string | null
@@ -408,8 +412,12 @@ export type Database = {
           pack?: string | null
           price?: number | null
           price_change_pct?: number | null
+          price_drop_smart_score?: number | null
           price_per_major_unit?: number | null
           price_recommended?: number | null
+          price_stats_cv_ln_90d?: number | null
+          price_stats_obs_90d?: number | null
+          price_stats_updated_at?: string | null
           priority?: number | null
           priority_source?: Database["public"]["Enums"]["priority_source_type"] | null
           priority_updated_at?: string | null
@@ -439,8 +447,12 @@ export type Database = {
           pack?: string | null
           price?: number | null
           price_change_pct?: number | null
+          price_drop_smart_score?: number | null
           price_per_major_unit?: number | null
           price_recommended?: number | null
+          price_stats_cv_ln_90d?: number | null
+          price_stats_obs_90d?: number | null
+          price_stats_updated_at?: string | null
           priority?: number | null
           priority_source?: Database["public"]["Enums"]["priority_source_type"] | null
           priority_updated_at?: string | null
@@ -628,8 +640,12 @@ export type Database = {
           pack: string | null
           price: number | null
           price_change_pct: number | null
+          price_drop_smart_score: number | null
           price_per_major_unit: number | null
           price_recommended: number | null
+          price_stats_cv_ln_90d: number | null
+          price_stats_obs_90d: number | null
+          price_stats_updated_at: string | null
           priority: number | null
           priority_source: Database["public"]["Enums"]["priority_source_type"] | null
           priority_updated_at: string | null
@@ -692,6 +708,10 @@ export type Database = {
       }
       compute_analytics_snapshot: {
         Args: { p_triggered_by?: string }
+        Returns: Json
+      }
+      refresh_store_product_price_stats_batch: {
+        Args: { p_batch_size?: number }
         Returns: Json
       }
       count_canonical_products: {

--- a/supabase/migrations/20260414_price_stats_volatility.sql
+++ b/supabase/migrations/20260414_price_stats_volatility.sql
@@ -1,0 +1,120 @@
+-- Denormalized price history stats per store_product (refreshed by batch RPC).
+ALTER TABLE public.store_products
+  ADD COLUMN IF NOT EXISTS price_stats_obs_90d integer,
+  ADD COLUMN IF NOT EXISTS price_stats_cv_ln_90d double precision,
+  ADD COLUMN IF NOT EXISTS price_stats_updated_at timestamptz,
+  ADD COLUMN IF NOT EXISTS price_drop_smart_score double precision;
+
+COMMENT ON COLUMN public.store_products.price_stats_obs_90d IS 'Count of price observations in the last 90 days (distinct prices rows)';
+COMMENT ON COLUMN public.store_products.price_stats_cv_ln_90d IS 'Population stddev of ln(price) over last 90 days; 0 if insufficient data';
+COMMENT ON COLUMN public.store_products.price_drop_smart_score IS 'Heuristic rank: larger = more trustworthy big drop; NULL if not a drop or thin history';
+
+CREATE INDEX IF NOT EXISTS idx_sp_price_drop_smart_score
+  ON public.store_products (price_drop_smart_score DESC NULLS LAST)
+  WHERE available = true AND name IS NOT NULL AND name <> '' AND price IS NOT NULL;
+
+-- Doc: ingest / pipeline review — last_http_status already on store_products; silent failures often leave bad price_change_pct or partial rows.
+
+CREATE OR REPLACE FUNCTION public.refresh_store_product_price_stats_batch(p_batch_size integer DEFAULT 2000)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_ids bigint[];
+  v_updated int := 0;
+  v_window_start timestamptz := now() - interval '90 days';
+BEGIN
+  IF p_batch_size IS NULL OR p_batch_size < 1 THEN
+    p_batch_size := 2000;
+  END IF;
+
+  SELECT coalesce(array_agg(s.id), ARRAY[]::bigint[])
+  INTO v_ids
+  FROM (
+    SELECT sp.id
+    FROM store_products sp
+    WHERE sp.available = true
+      AND EXISTS (
+        SELECT 1
+        FROM prices p
+        WHERE p.store_product_id = sp.id
+          AND p.price IS NOT NULL AND p.price > 0
+          AND p.valid_from >= v_window_start
+      )
+      AND (
+        sp.price_stats_updated_at IS NULL
+        OR sp.updated_at > sp.price_stats_updated_at
+        OR (sp.last_price_change_at IS NOT NULL AND sp.last_price_change_at > sp.price_stats_updated_at)
+      )
+    ORDER BY sp.id
+    LIMIT p_batch_size
+  ) s;
+
+  IF cardinality(v_ids) = 0 THEN
+    RETURN jsonb_build_object('processed', 0, 'batch_size', p_batch_size);
+  END IF;
+
+  WITH stats AS (
+    SELECT
+      p.store_product_id,
+      count(*)::integer AS obs_90d,
+      coalesce(stddev_pop(ln(p.price)), 0)::double precision AS cv_ln
+    FROM prices p
+    WHERE p.store_product_id = ANY (v_ids)
+      AND p.price IS NOT NULL AND p.price > 0
+      AND p.valid_from >= v_window_start
+    GROUP BY p.store_product_id
+  ),
+  merged AS (
+    SELECT
+      sp.id,
+      coalesce(st.obs_90d, 0) AS obs_90d,
+      CASE
+        WHEN st.obs_90d IS NULL OR st.obs_90d < 2 THEN 0::double precision
+        ELSE st.cv_ln
+      END AS cv_ln
+    FROM store_products sp
+    LEFT JOIN stats st ON st.store_product_id = sp.id
+    WHERE sp.id = ANY (v_ids)
+  ),
+  upd AS (
+    UPDATE store_products sp
+    SET
+      price_stats_obs_90d = m.obs_90d,
+      price_stats_cv_ln_90d = m.cv_ln,
+      price_stats_updated_at = now(),
+      price_drop_smart_score =
+        CASE
+          WHEN sp.price_change_pct IS NOT NULL AND sp.price_change_pct < 0
+            AND m.obs_90d >= 2 AND m.cv_ln > 1e-12
+          THEN
+            least(1::double precision, m.obs_90d::double precision / 8.0)
+            * least(1::double precision, (m.cv_ln / 0.08)::double precision)
+            * abs(sp.price_change_pct::double precision)
+          WHEN sp.price_change_pct IS NOT NULL
+            AND sp.price_change_pct < 0
+            AND m.obs_90d >= 2 THEN
+            least(1::double precision, m.obs_90d::double precision / 8.0)
+            * 0.15::double precision
+            * abs(sp.price_change_pct::double precision)
+          ELSE NULL
+        END
+    FROM merged m
+    WHERE sp.id = m.id
+    RETURNING sp.id
+  )
+  SELECT count(*)::integer INTO v_updated FROM upd;
+
+  RETURN jsonb_build_object(
+    'processed', v_updated,
+    'batch_size', p_batch_size,
+    'candidate_ids', cardinality(v_ids)
+  );
+END;
+$$;
+
+ALTER FUNCTION public.refresh_store_product_price_stats_batch(integer) OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.refresh_store_product_price_stats_batch(integer) TO service_role;

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,10 @@
       "schedule": "0 */12 * * *"
     },
     {
+      "path": "/api/admin/price-stats-worker",
+      "schedule": "30 */12 * * *"
+    },
+    {
       "path": "/api/admin/alerts/scrape-health",
       "schedule": "0 */8 * * *"
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the agreed plan: fix `price_change_pct` semantics (DB stores a **ratio**, not percent points), add **listing quality gates** for deal-like sorts, introduce **precomputed 90d price stats** and an opt-in **`price-drop-smart`** sort, harden **deals** and **hero** queries, improve **card** behavior when `price` is missing, nudge **scheduler** urgency using volatility, and document **ingest quality** expectations on the scraper base class.

## Database

- New migration [`supabase/migrations/20260414_price_stats_volatility.sql`](supabase/migrations/20260414_price_stats_volatility.sql): columns `price_stats_obs_90d`, `price_stats_cv_ln_90d`, `price_stats_updated_at`, `price_drop_smart_score`; function `refresh_store_product_price_stats_batch(batch_size)`.
- **Deploy:** apply migration to production, then ensure `CRON_SECRET` is set for the new cron route (same as other admin crons).

## App / API

- [`src/lib/business/price-change.ts`](src/lib/business/price-change.ts): shared helpers + `PLAUSIBLE_MAX_PRICE_CHANGE_MAGNITUDE` (0.65), recency default (14d).
- Stats & alerts: [`src/app/api/user/stats/route.ts`](src/app/api/user/stats/route.ts), [`src/app/api/admin/alerts/price-drops/route.ts`](src/app/api/admin/alerts/price-drops/route.ts).
- Browse: [`src/lib/queries/store-products/query.ts`](src/lib/queries/store-products/query.ts) — filters + `price-drop-smart` order; [`src/types/business.ts`](src/types/business.ts) + [`src/lib/business/filters.ts`](src/lib/business/filters.ts).
- Deals & hero: [`src/lib/queries/deals.ts`](src/lib/queries/deals.ts), [`src/lib/business/hero.ts`](src/lib/business/hero.ts).
- Card: [`src/components/products/StoreProductCard.tsx`](src/components/products/StoreProductCard.tsx).
- Cron: [`src/app/api/admin/price-stats-worker/route.ts`](src/app/api/admin/price-stats-worker/route.ts) + [`vercel.json`](vercel.json).
- Scheduler: [`src/app/api/scrape/scheduler/route.ts`](src/app/api/scrape/scheduler/route.ts) — small urgency boost from `price_stats_cv_ln_90d`.
- Alert API: [`src/app/api/alerts/route.ts`](src/app/api/alerts/route.ts) — if client sends percentage threshold as whole percent (e.g. 10), normalize to ratio (0.10) for comparison with `price_change_pct`.

## Types

- [`src/types/supabase.ts`](src/types/supabase.ts) and [`src/types/index.ts`](src/types/index.ts) updated for new columns and RPC.

## Notes

- `pnpm check` fails in this environment on missing image assets (pre-existing); changed files pass targeted ESLint.
- Until the migration runs and the batch job backfills rows, **`price-drop-smart` may return fewer results** (requires non-null `price_drop_smart_score`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-682a0f54-6929-48bb-a7ed-c5dd2ba5e8be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-682a0f54-6929-48bb-a7ed-c5dd2ba5e8be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

